### PR TITLE
make-fnv-typed-vector: Specify :copier NIL for defstruct.

### DIFF
--- a/foreign-numeric-vector.lisp
+++ b/foreign-numeric-vector.lisp
@@ -77,7 +77,8 @@
 	   (foreign-elt-size (foreign-type-size cffi-underlying-type)))
       (with-gensyms (index-sym val-sym fnv-ptr-ref-sym)
 	`(progn
-	  (defstruct (,fnv-name (:constructor ,constructor))
+	  (defstruct (,fnv-name (:constructor ,constructor)
+                                (:copier nil))
 	    (foreign-pointer nil :read-only t)
 	    (length 0 :type fixnum :read-only t))
 	  
@@ -348,5 +349,3 @@
 				 ((lambda (i j)
 				    (< (imagpart i) (imagpart j)))
 				  imagpart-<)))
-
-


### PR DESCRIPTION
It creates its own copy functions, which redefines the one created by
defstruct and causes warnings.

Older versions of SBCL didn't warn about such redefinition, now it does.
